### PR TITLE
chore: add placeholder test package structure

### DIFF
--- a/home-assistant/packages/test.yaml
+++ b/home-assistant/packages/test.yaml
@@ -1,0 +1,12 @@
+# =============================================================================
+# PACKAGE: test.yaml
+# PURPOSE: Placeholder Home Assistant package for validation tests
+# ISSUE: #0 (placeholder tracking)
+# DEPENDS ON:
+#   - None (empty scaffold)
+# TESTED ON: Pending automated validation
+# NOTES:
+#   - Minimal structure to satisfy ADR-0006 header requirements and linting.
+# =============================================================================
+
+homeassistant: {}


### PR DESCRIPTION
## Summary
- add an ADR-0006-compliant header and placeholder `homeassistant: {}` body to the test package so the file is a valid package scaffold

## Testing
- `yamllint -c .yamllint home-assistant` *(fails: `yamllint` unavailable in environment; pip/apt access blocked by proxy 403)*
- `ha core check` *(fails: `ha` CLI unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb719fbce4832591d7c2f57f486d8c