### PR TITLE
Fix Shelly shelves script service targets

### DIFF
--- a/home-assistant/packages/shelly_shelves.yaml
+++ b/home-assistant/packages/shelly_shelves.yaml
@@ -266,8 +266,8 @@ script:
             - light.shelf_4
           sequence:
             - service: light.turn_on
-              target: { entity_id: "{{ repeat.item }}" }
               data:
+                entity_id: "{{ repeat.item }}"
                 transition: 0
 
   # ---- Doorbell Flash (scene snapshot → red x3 → restore) ----
@@ -318,8 +318,8 @@ script:
             - light.shelf_4
           sequence:
             - service: light.turn_on
-              target: { entity_id: "{{ repeat.item }}" }
               data:
+                entity_id: "{{ repeat.item }}"
                 transition: 0
 
   # ---- (Optional) Shelf 2 – Probe Restore (single-light test) ----
@@ -377,8 +377,8 @@ script:
           for_each: "{{ targets }}"
           sequence:
             - service: light.turn_on
-              target: { entity_id: "{{ repeat.item }}" }
               data:
+                entity_id: "{{ repeat.item }}"
                 rgbw_color: [ "{{ r }}", "{{ g }}", "{{ b }}", "{{ w }}" ]
                 brightness_pct: "{{ bp }}"
                 transition: "{{ tr }}"


### PR DESCRIPTION
## Summary
- move templated entity IDs from `target` into service data in the Shelly shelves scripts
- ensure per-light loops provide concrete `entity_id` values during fan-out

## Testing
- `yamllint -c .yamllint home-assistant/packages/shelly_shelves.yaml` *(fails: `yamllint` not installed and cannot be fetched because outbound HTTP is blocked in the execution environment)*
- `ha core check` *(fails: `ha` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cccab4671c8325802dcfb9e78b9f53