### PR TITLE
Simplify Shelly shelves target list handling

### DIFF
--- a/packages/shelly_shelves.yaml
+++ b/packages/shelly_shelves.yaml
@@ -370,7 +370,7 @@ script:
                 {% set _ = ns.result.append(item | string) %}
               {% endif %}
             {% endfor %}
-            {{ ns.result | to_json }}
+            {{ ns.result }}
           r: "{{ rgbw[0] | int }}"
           g: "{{ rgbw[1] | int }}"
           b: "{{ rgbw[2] | int }}"
@@ -378,13 +378,12 @@ script:
           bp: "{{ bright | int }}"
           tr: "{{ trans | float(0) }}"
       - repeat:
-          for_each: "{{ targets_json | from_json }}"
+          for_each: "{{ targets_json }}"
           sequence:
             - service: light.turn_on
               target:
                 entity_id: "{{ repeat.item }}"
               data:
-                entity_id: "{{ repeat.item }}"
                 rgbw_color: [ "{{ r }}", "{{ g }}", "{{ b }}", "{{ w }}" ]
                 brightness_pct: "{{ bp }}"
                 transition: "{{ tr }}"


### PR DESCRIPTION
## Summary
- convert the `shelves_apply` helper to keep `targets_json` as a real list instead of encoding/decoding JSON
- update the repeat loop to iterate over that list directly and rely on `target.entity_id` without duplicating the entity in the data payload

## Testing
- ⚠️ `yamllint -c .yamllint packages/shelly_shelves.yaml` *(not available in container; pip install blocked by proxy)*
- ⚠️ `python -m homeassistant --script check_config -c /config` *(Home Assistant package unavailable; pip install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ceff0795c48325ab57bf077603dd25