### PR TITLE
Refine Ring doorbell player handling

### DIFF
--- a/packages/ring.yaml
+++ b/packages/ring.yaml
@@ -19,47 +19,80 @@ script:
     alias: Sonos - Doorbell Chime (Kitchen + Patio)
     mode: single
     variables:
+      players:
+        - media_player.kitchen
+        - media_player.patio
       chime_url: "media-source://media_source/local/dingdong.mp3"  # /config/www/dingdong.mp3
       chime_vol: 0.40
       chime_len: "00:00:03"
     sequence:
+      - variables:
+          players: >-
+            {% set candidate = players | default([], true) %}
+            {% if candidate is mapping and 'entity_id' in candidate %}
+              {% set candidate = candidate.entity_id %}
+            {% endif %}
+            {% if candidate is none %}
+              {% set items = [] %}
+            {% elif candidate is iterable and candidate is not string %}
+              {% set items = candidate | list %}
+            {% else %}
+              {% set items = [candidate] %}
+            {% endif %}
+            {% set ns = namespace(result=[]) %}
+            {% for item in items %}
+              {% if item is mapping and 'entity_id' in item %}
+                {% set inner = item.entity_id %}
+                {% if inner is iterable and inner is not string %}
+                  {% for entity in inner %}
+                    {% if entity is not none %}
+                      {% set _ = ns.result.append(entity | string) %}
+                    {% endif %}
+                  {% endfor %}
+                {% elif inner is not none %}
+                  {% set _ = ns.result.append(inner | string) %}
+                {% endif %}
+              {% elif item is iterable and item is not string %}
+                {% for entity in item %}
+                  {% if entity is not none %}
+                    {% set _ = ns.result.append(entity | string) %}
+                  {% endif %}
+                {% endfor %}
+              {% elif item is not none %}
+                {% set _ = ns.result.append(item | string) %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.result }}
+      - condition: template
+        value_template: "{{ players | count > 0 }}"
       - service: sonos.snapshot
         target:
-          entity_id:
-            - media_player.kitchen
-            - media_player.patio
+          entity_id: "{{ players }}"
         data:
           with_group: true
-      - service: media_player.volume_set
-        target:
-          entity_id: media_player.kitchen
-        data:
-          volume_level: "{{ chime_vol | float }}"
-      - service: media_player.volume_set
-        target:
-          entity_id: media_player.patio
-        data:
-          volume_level: "{{ chime_vol | float }}"
-      - service: media_player.play_media
-        target:
-          entity_id: media_player.kitchen
-        data:
-          media_content_id: "{{ chime_url }}"
-          media_content_type: music
-      - delay: "00:00:00.20"
-      - service: media_player.play_media
-        target:
-          entity_id: media_player.patio
-        data:
-          media_content_id: "{{ chime_url }}"
-          media_content_type: music
-      - delay: "00:00:00.20"
+      - repeat:
+          for_each: "{{ players }}"
+          sequence:
+            - service: media_player.volume_set
+              target:
+                entity_id: "{{ repeat.item }}"
+              data:
+                volume_level: "{{ chime_vol | float }}"
+      - repeat:
+          for_each: "{{ players }}"
+          sequence:
+            - service: media_player.play_media
+              target:
+                entity_id: "{{ repeat.item }}"
+              data:
+                entity_id: "{{ repeat.item }}"
+                media_content_id: "{{ chime_url }}"
+                media_content_type: music
+            - delay: "00:00:00.20"
       - delay: "{{ chime_len }}"
       - service: sonos.restore
         target:
-          entity_id:
-            - media_player.kitchen
-            - media_player.patio
+          entity_id: "{{ players }}"
         data:
           with_group: true
 


### PR DESCRIPTION
## Summary
- normalize the Sonos doorbell chime script to resolve its player list once and reuse it for all services
- drive the snapshot/restore targets and repeat loops directly from the resolved player list

## Testing
- ⚠️ `yamllint -c .yamllint packages/ring.yaml` *(fails: yamllint unavailable in execution environment)*
- ⚠️ `python -m homeassistant --script check_config -c /config` *(fails: homeassistant module not installed in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceff0821ac83259c96064552b579a7