### PR TITLE
Fix Sonos doorbell player count template

### DIFF
--- a/packages/ring.yaml
+++ b/packages/ring.yaml
@@ -64,7 +64,7 @@ script:
             {% endfor %}
             {{ ns.result }}
       - condition: template
-        value_template: "{{ players | count > 0 }}"
+        value_template: "{{ players | length > 0 }}"
       - service: sonos.snapshot
         target:
           entity_id: "{{ players }}"


### PR DESCRIPTION
## Summary
- fix the Sonos doorbell script guard to use the `length` filter to count players

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cf058597f08325a3b74cc46469056d