### PR TITLE
Update Sonos scripts to use template mapping

### DIFF
--- a/packages/sonos.yaml
+++ b/packages/sonos.yaml
@@ -65,7 +65,8 @@ script:
       - condition: template
         value_template: "{{ player_list | length > 0 }}"
       - repeat:
-          for_each: player_list
+          for_each:
+            template: "{{ player_list }}"
           sequence:
             - service: sonos.snapshot
               target:
@@ -120,7 +121,8 @@ script:
       - condition: template
         value_template: "{{ player_list | length > 0 }}"
       - repeat:
-          for_each: player_list
+          for_each:
+            template: "{{ player_list }}"
           sequence:
             - service: sonos.restore
               target:
@@ -397,15 +399,21 @@ script:
         value_template: "{{ players_list | length > 0 }}"
       - service: script.sonos_snapshot
         data:
-          players: players_list
+          players:
+            template: "{{ players_list }}"
       - choose:
           - conditions: "{{ volume is defined }}"
             sequence:
-              - service: media_player.volume_set
-                target:
-                  entity_id: players_list
-                data:
-                  volume_level: "{{ volume | float }}"
+              - repeat:
+                  for_each:
+                    template: "{{ players_list }}"
+                  sequence:
+                    - service: media_player.volume_set
+                      target:
+                        entity_id:
+                          template: "{{ repeat.item }}"
+                      data:
+                        volume_level: "{{ volume | float }}"
       - service: "{{ tts }}"
         target:
           entity_id: "{{ players_list[0] }}"
@@ -414,7 +422,8 @@ script:
       - delay: "00:00:04"
       - service: script.sonos_restore_snapshot
         data:
-          players: players_list
+          players:
+            template: "{{ players_list }}"
 
   # ---------- GROUP PRESETS / TRANSFERS ----------
   tv_plus_kitchen:


### PR DESCRIPTION
## Summary
- switch the Sonos snapshot and restore helpers to the new repeat for_each template syntax
- adjust the Sonos announce script to pass player lists through template mappings and iterate volume calls

## Testing
- docker exec -it homeassistant python -m homeassistant --script check_config -c /config *(fails: docker command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0f06d3608325a514b2069677d4b1