### PR TITLE
Fix Sonos repeat templating

### DIFF
--- a/packages/sonos.yaml
+++ b/packages/sonos.yaml
@@ -401,11 +401,14 @@ script:
       - choose:
           - conditions: "{{ volume is defined }}"
             sequence:
-              - service: media_player.volume_set
-                target:
-                  entity_id: players_list
-                data:
-                  volume_level: "{{ volume | float }}"
+              - repeat:
+                  for_each: players_list
+                  sequence:
+                    - service: media_player.volume_set
+                      target:
+                        entity_id: "{{ repeat.item }}"
+                      data:
+                        volume_level: "{{ volume | float }}"
       - service: "{{ tts }}"
         target:
           entity_id: "{{ players_list[0] }}"


### PR DESCRIPTION
## Summary
- restore the Sonos snapshot and restore helpers to loop over the resolved player list directly so the configuration validates
- keep the announce script calling the helpers with that list and iterate volume adjustments per player without the unsupported template mappings

## Testing
- docker exec -it homeassistant python -m homeassistant --script check_config -c /config *(fails: `docker` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0f06d3608325a514b2069677d4b1