### PR TITLE
Harden TV in Kitchen fallback and adopt templated loops

### DIFF
--- a/packages/sonos.yaml
+++ b/packages/sonos.yaml
@@ -65,7 +65,8 @@ script:
       - condition: template
         value_template: "{{ player_list | length > 0 }}"
       - repeat:
-          for_each: player_list
+          for_each:
+            template: "{{ player_list }}"
           sequence:
             - service: sonos.snapshot
               target:
@@ -120,7 +121,8 @@ script:
       - condition: template
         value_template: "{{ player_list | length > 0 }}"
       - repeat:
-          for_each: player_list
+          for_each:
+            template: "{{ player_list }}"
           sequence:
             - service: sonos.restore
               target:
@@ -397,15 +399,21 @@ script:
         value_template: "{{ players_list | length > 0 }}"
       - service: script.sonos_snapshot
         data:
-          players: players_list
+          players:
+            template: "{{ players_list }}"
       - choose:
           - conditions: "{{ volume is defined }}"
             sequence:
-              - service: media_player.volume_set
-                target:
-                  entity_id: players_list
-                data:
-                  volume_level: "{{ volume | float }}"
+              - repeat:
+                  for_each:
+                    template: "{{ players_list }}"
+                  sequence:
+                    - service: media_player.volume_set
+                      target:
+                        entity_id:
+                          template: "{{ repeat.item }}"
+                      data:
+                        volume_level: "{{ volume | float }}"
       - service: "{{ tts }}"
         target:
           entity_id: "{{ players_list[0] }}"
@@ -414,7 +422,8 @@ script:
       - delay: "00:00:04"
       - service: script.sonos_restore_snapshot
         data:
-          players: players_list
+          players:
+            template: "{{ players_list }}"
 
   # ---------- GROUP PRESETS / TRANSFERS ----------
   tv_plus_kitchen:
@@ -467,7 +476,31 @@ script:
       - choose:
           - conditions: "{{ state_attr('media_player.family_room', 'source') == 'TV' }}"
             sequence:
-              - service: script.tv_plus_kitchen
+              - choose:
+                  - conditions: "{{ states('script.tv_plus_kitchen') not in ['unknown', 'unavailable'] }}"
+                    sequence:
+                      - service: script.turn_on
+                        target:
+                          entity_id: script.tv_plus_kitchen
+                      - wait_template: >
+                          {{ state_attr('media_player.family_room', 'group_members') is defined
+                             and 'media_player.kitchen' in state_attr('media_player.family_room', 'group_members') }}
+                        timeout: "00:00:03"
+                        continue_on_timeout: true
+              - choose:
+                  - conditions: >
+                      {{ state_attr('media_player.family_room', 'group_members') is defined
+                         and 'media_player.kitchen' in state_attr('media_player.family_room', 'group_members') }}
+                    sequence: []
+                default:
+                  - service: script.sonos_group_with
+                    data:
+                      coordinator: media_player.family_room
+                      members:
+                        - media_player.kitchen
+              - service: media_player.volume_set
+                target: { entity_id: media_player.kitchen }
+                data: { volume_level: 0.10 }
         default:
           - service: script.sonos_move
             data: { source: media_player.family_room, dest: media_player.kitchen }


### PR DESCRIPTION
## Summary
- adopt the new templated `for_each` structure in the Sonos snapshot/restore helpers and the announce script
- pass Sonos announce player lists through templated mappings and adjust volumes per player with the new syntax
- wait for the TV and Kitchen preset to succeed before falling back to manual grouping and volume control when needed

## Testing
- not run (container image does not provide `docker` to execute `homeassistant --script check_config`)


------
https://chatgpt.com/codex/tasks/task_e_68cf0f06d3608325a514b2069677d4b1