### PR TITLE
Fix Sonos repeat for_each syntax to string form

### DIFF
--- a/packages/sonos.yaml
+++ b/packages/sonos.yaml
@@ -65,8 +65,7 @@ script:
       - condition: template
         value_template: "{{ player_list | length > 0 }}"
       - repeat:
-          for_each:
-            template: "{{ player_list }}"
+          for_each: "{{ player_list }}"
           sequence:
             - service: sonos.snapshot
               target:
@@ -121,8 +120,7 @@ script:
       - condition: template
         value_template: "{{ player_list | length > 0 }}"
       - repeat:
-          for_each:
-            template: "{{ player_list }}"
+          for_each: "{{ player_list }}"
           sequence:
             - service: sonos.restore
               target:
@@ -405,8 +403,7 @@ script:
           - conditions: "{{ volume is defined }}"
             sequence:
               - repeat:
-                  for_each:
-                    template: "{{ players_list }}"
+                  for_each: "{{ players_list }}"
                   sequence:
                     - service: media_player.volume_set
                       target:


### PR DESCRIPTION
## Summary
- switch the repeat `for_each` blocks in the Sonos snapshot, restore, and announce scripts back to the string template form for compatibility

## Testing
- `ha_check` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf249505588325b337f038f22abc87