### PR TITLE
fix: adjust sonos announce volume targeting

### DIFF
--- a/packages/sonos.yaml
+++ b/packages/sonos.yaml
@@ -407,8 +407,7 @@ script:
                   sequence:
                     - service: media_player.volume_set
                       target:
-                        entity_id:
-                          template: "{{ repeat.item }}"
+                        entity_id: "{{ repeat.item }}"
                       data:
                         volume_level: "{{ volume | float }}"
       - service: "{{ tts }}"


### PR DESCRIPTION
## Summary
- update the Sonos announce helper to assign the repeat entity directly to the volume-set call

## Testing
- `ha_check` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf25652ad08325b21a8f61b7f00dd0