### PR TITLE
Fix Sonos announce snapshot player list

### DIFF
--- a/packages/sonos.yaml
+++ b/packages/sonos.yaml
@@ -397,8 +397,7 @@ script:
         value_template: "{{ players_list | length > 0 }}"
       - service: script.sonos_snapshot
         data:
-          players:
-            template: "{{ players_list }}"
+          players: "{{ players_list }}"
       - choose:
           - conditions: "{{ volume is defined }}"
             sequence:
@@ -418,8 +417,7 @@ script:
       - delay: "00:00:04"
       - service: script.sonos_restore_snapshot
         data:
-          players:
-            template: "{{ players_list }}"
+          players: "{{ players_list }}"
 
   # ---------- GROUP PRESETS / TRANSFERS ----------
   tv_plus_kitchen:


### PR DESCRIPTION
## Summary
- pass the computed players_list directly to the Sonos snapshot/restore helpers used by the announce script

## Testing
- ha_check *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2618c64c8325bbcaca1f64849ab3