### PR TITLE
Normalize Ring ding condition data parsing

### DIFF
--- a/packages/ring.yaml
+++ b/packages/ring.yaml
@@ -62,7 +62,7 @@ script:
                 {% set _ = ns.result.append(item | string) %}
               {% endif %}
             {% endfor %}
-            {{ ns.result }}
+            {{ ns.result | list }}
       - condition: template
         value_template: "{{ players | length > 0 }}"
       - service: sonos.snapshot
@@ -103,34 +103,28 @@ automation:
     trigger:
       - platform: state
         entity_id: event.front_door_ding   # state changes to a new timestamp each press
+    variables:
+      ring_attrs: "{{ trigger.to_state.attributes }}"
+      ring_event_type: "{{ ring_attrs.get('event_type') }}"
+      ring_raw_data: "{{ ring_attrs.get('event_data') }}"
+      ring_parsed_data: "{{ ring_raw_data | from_json(default=dict()) if ring_raw_data is string else dict() }}"
+      ring_data: >-
+        {{ iif(ring_raw_data is mapping,
+               ring_raw_data,
+               iif(ring_parsed_data is mapping, ring_parsed_data, dict())) }}
+      ring_kind: "{{ ring_data.get('kind') }}"
+      ring_state: "{{ ring_data.get('state') }}"
+      ring_motion: "{{ ring_data.get('motion') }}"
+      ring_button_state: "{{ ring_data.get('doorbellStatus') }}"
+      ring_motion_clear: "{{ ring_motion in [none, false, 'false', 'False'] }}"
     condition:
       - condition: template
         value_template: >-
-          {% set attrs = trigger.to_state.attributes %}
-          {% set event_type = attrs.get('event_type') %}
-          {% set raw_data = attrs.get('event_data') %}
-          {% if raw_data is string %}
-            {% set parsed = raw_data | from_json %}
-            {% if parsed is mapping %}
-              {% set data = parsed %}
-            {% else %}
-              {% set data = {} %}
-            {% endif %}
-          {% elif raw_data is mapping %}
-            {% set data = raw_data %}
-          {% else %}
-            {% set data = {} %}
-          {% endif %}
-          {% set kind = data.get('kind') %}
-          {% set state = data.get('state') %}
-          {% set motion = data.get('motion') %}
-          {% set button_state = data.get('doorbellStatus') %}
-          {% set valid_states = ['ringing', 'starting', 'doorbell', 'button', 'on_demand'] %}
-          {% set motion_clear = motion in [none, false, 'false', 'False'] %}
-          {{ event_type == 'ding'
-             and (kind is none or kind in ['ding', 'doorbell', 'on_demand_ding', 'remote_ding'])
-             and (state is none or state in valid_states or button_state in ['ringing', 'pressed', 'start'])
-             and motion_clear }}
+          {{ ring_event_type == 'ding'
+             and (ring_kind is none or ring_kind in ['ding', 'doorbell', 'on_demand_ding', 'remote_ding'])
+             and (ring_state is none or ring_state in ['ringing', 'starting', 'doorbell', 'button', 'on_demand']
+                  or ring_button_state in ['ringing', 'pressed', 'start'])
+             and ring_motion_clear }}
 
     action:
       - service: script.shelves_doorbell_flash

--- a/packages/sonos.yaml
+++ b/packages/sonos.yaml
@@ -397,8 +397,7 @@ script:
         value_template: "{{ players_list | length > 0 }}"
       - service: script.sonos_snapshot
         data:
-          players:
-            template: "{{ players_list }}"
+          players: "{{ players_list }}"
       - choose:
           - conditions: "{{ volume is defined }}"
             sequence:
@@ -418,8 +417,7 @@ script:
       - delay: "00:00:04"
       - service: script.sonos_restore_snapshot
         data:
-          players:
-            template: "{{ players_list }}"
+          players: "{{ players_list }}"
 
   # ---------- GROUP PRESETS / TRANSFERS ----------
   tv_plus_kitchen:


### PR DESCRIPTION
## Summary
- precompute Ring doorbell event metadata in automation-scoped variables so the condition template no longer embeds block statements the YAML loader chokes on
- simplify the condition to reference the normalized fields and reuse the existing motion-safe guard list

## Testing
- ha_check *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2618c64c8325bbcaca1f64849ab3