### PR TITLE
Fix template closing and sequence indentation in ring package

### DIFF
--- a/packages/ring.yaml
+++ b/packages/ring.yaml
@@ -110,9 +110,9 @@ script:
             {% endfor %}
             {{ ns.result | list }}
       - condition: template
-        value_template: "{{ player_list | length > 0 }
-     
-     - service: sonos.snapshot
+        value_template: "{{ player_list | length > 0 }}"
+
+      - service: sonos.snapshot
         target:
           entity_id: "{{ player_list }}"
         data:


### PR DESCRIPTION
## Summary
- close the `value_template` Jinja expression so the ring package parses correctly
- fix indentation of the `sonos.snapshot` call so it remains within the script sequence

## Testing
- `ha core check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d30ba406bc83259a8175e0ac9be741