### PR TITLE
Fix doorbell handler task wait invocation

### DIFF
--- a/pyscript/apps/doorbell.py
+++ b/pyscript/apps/doorbell.py
@@ -243,6 +243,6 @@ async def ring_doorbell_handler(value: str | None = None, **kwargs: Any) -> None
     chime_task = task.create(_run_sonos_doorbell_chime())
     flash_task = task.create(_run_shelves_doorbell_flash())
     try:
-        await task.wait_all([chime_task, flash_task])
+        await task.wait_all(chime_task, flash_task)
     finally:
         await task.sleep(4.0)


### PR DESCRIPTION
## Summary
- call task.wait_all with separate arguments in the doorbell handler to avoid passing a list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d313c3b4c0832584e095bc4b718fbe