### PR TITLE
fix: restore ring chime script template formatting

### DIFF
--- a/packages/ring.yaml
+++ b/packages/ring.yaml
@@ -12,7 +12,88 @@
 #   - The doorbell ding flow now lives in pyscript/apps/doorbell.py and exposes
 #     pyscript.sonos_doorbell_chime_py + pyscript.shelves_doorbell_flash_py services.
 #   - Legacy YAML automation/scripts were removed once the Pyscript handler became
-#     authoritative to prevent duplicate flows.
+#     authoritative to prevent duplicate flows, but the core chime script remains
+#     here as a fallback/testing helper.
 # =============================================================================
 
-# Intentionally left empty; see pyscript/apps/doorbell.py for the live implementation.
+script:
+  sonos_doorbell_chime:
+    alias: Sonos - Doorbell Chime (Kitchen + Patio)
+    mode: single
+    variables:
+      players:
+        - media_player.kitchen
+        - media_player.patio
+      chime_url: "media-source://media_source/local/dingdong.mp3"  # /config/www/dingdong.mp3
+      chime_vol: 0.40
+      chime_len: "00:00:03"
+    sequence:
+      - variables:
+          player_list: >-
+            {% set candidate = players | default([], true) %}
+            {% if candidate is mapping and 'entity_id' in candidate %}
+              {% set candidate = candidate.entity_id %}
+            {% endif %}
+            {% if candidate is none %}
+              {% set items = [] %}
+            {% elif candidate is iterable and candidate is not string %}
+              {% set items = candidate | list %}
+            {% else %}
+              {% set items = [candidate] %}
+            {% endif %}
+            {% set ns = namespace(result=[]) %}
+            {% for item in items %}
+              {% if item is mapping and 'entity_id' in item %}
+                {% set inner = item.entity_id %}
+                {% if inner is iterable and inner is not string %}
+                  {% for entity in inner %}
+                    {% if entity is not none %}
+                      {% set ns.result = ns.result + [(entity | string)] %}
+                    {% endif %}
+                  {% endfor %}
+                {% elif inner is not none %}
+                  {% set ns.result = ns.result + [(inner | string)] %}
+                {% endif %}
+              {% elif item is iterable and item is not string %}
+                {% for entity in item %}
+                  {% if entity is not none %}
+                    {% set ns.result = ns.result + [(entity | string)] %}
+                  {% endif %}
+                {% endfor %}
+              {% elif item is not none %}
+                {% set ns.result = ns.result + [(item | string)] %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.result | list }}
+      - condition: template
+        value_template: "{{ player_list | length > 0 }}"
+      - service: sonos.snapshot
+        target:
+          entity_id: "{{ player_list }}"
+        data:
+          with_group: true
+      - repeat:
+          for_each: "{{ player_list }}"
+          sequence:
+            - service: media_player.volume_set
+              target:
+                entity_id: "{{ repeat.item }}"
+              data:
+                volume_level: "{{ chime_vol | float }}"
+      - repeat:
+          for_each: "{{ player_list }}"
+          sequence:
+            - service: media_player.play_media
+              target:
+                entity_id: "{{ repeat.item }}"
+              data:
+                entity_id: "{{ repeat.item }}"
+                media_content_id: "{{ chime_url }}"
+                media_content_type: music
+            - delay: "00:00:00.20"
+      - delay: "{{ chime_len }}"
+      - service: sonos.restore
+        target:
+          entity_id: "{{ player_list }}"
+        data:
+          with_group: true


### PR DESCRIPTION
## Summary
- restore the Ring Sonos chime fallback script so the template guard closes with `}}`
- realign the `sonos.snapshot` call within the script sequence to fix the YAML structure

## Testing
- `ha core check` *(fails: `ha` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d312d93894832589c189e66cda991e