### PR TITLE
Fix Shelly shelves rgbw template list

### DIFF
--- a/packages/shelly_shelves.yaml
+++ b/packages/shelly_shelves.yaml
@@ -376,7 +376,11 @@ script:
               target:
                 entity_id: "{{ repeat.item }}"
               data:
-                rgbw_color: [ {{ r }}, {{ g }}, {{ b }}, {{ w }} ]
+                rgbw_color:
+                  - {{ r | int }}
+                  - {{ g | int }}
+                  - {{ b | int }}
+                  - {{ w | int }}
                 brightness_pct: {{ bp }}
                 transition: {{ tr }}
 


### PR DESCRIPTION
## Summary
- expand the Shelly shelves rgbw_color payload to a block-style sequence so the YAML parser no longer encounters an inline list with braces
- keep each channel cast to an integer before passing values to light.turn_on

## Testing
- ha core check *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d708d171808325914b1dbe988fdb5c