### PR TITLE
Fix Shelly shelves rgbw_color templating

### DIFF
--- a/packages/shelly_shelves.yaml
+++ b/packages/shelly_shelves.yaml
@@ -377,10 +377,10 @@ script:
                 entity_id: "{{ repeat.item }}"
               data:
                 rgbw_color:
-                  - {{ r | int }}
-                  - {{ g | int }}
-                  - {{ b | int }}
-                  - {{ w | int }}
+                  - "{{ r | int }}"
+                  - "{{ g | int }}"
+                  - "{{ b | int }}"
+                  - "{{ w | int }}"
                 brightness_pct: {{ bp }}
                 transition: {{ tr }}
 


### PR DESCRIPTION
## Summary
- quote Shelly shelves rgbw_color template list items to avoid YAML parsing issues

## Testing
- ha_check *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d70aa5e7ac83258c1687418c08aaec