### PR TITLE
Ensure shelves_apply target expansion emits valid lists

### DIFF
--- a/packages/shelly_shelves.yaml
+++ b/packages/shelly_shelves.yaml
@@ -325,44 +325,10 @@ script:
     sequence:
       - variables:
           grp: "{{ group | default('light.shelves_all', true) }}"
-          expanded: "{{ expand(grp) | map(attribute='entity_id') | list }}"
-          targets_json: >-
-            {% set base = expanded if expanded else grp %}
-            {% if base is mapping and 'entity_id' in base %}
-              {% set base = base.entity_id %}
-            {% endif %}
-            {% if base is none %}
-              {% set items = [] %}
-            {% elif base is iterable and base is not string %}
-              {% set items = base | list %}
-            {% else %}
-              {% set items = [base] %}
-            {% endif %}
-            {% set ns = namespace(result=[]) %}
-            {% for item in items %}
-              {% if item is mapping and 'entity_id' in item %}
-                {% set inner = item.entity_id %}
-                {% if inner is iterable and inner is not string %}
-                  {% for entity in inner %}
-                    {% if entity is not none %}
-                      {% set ns.result = ns.result + [(entity | string)] %}
-                    {% endif %}
-                  {% endfor %}
-                {% elif inner is not none %}
-                  {% set ns.result = ns.result + [(inner | string)] %}
-                {% endif %}
-              {% elif item is iterable and item is not string %}
-                {% for entity in item %}
-                  {% if entity is not none %}
-                    {% set ns.result = ns.result + [(entity | string)] %}
-                  {% endif %}
-                {% endfor %}
-              {% elif item is not none %}
-                {% set ns.result = ns.result + [(item | string)] %}
-              {% endif %}
-            {% endfor %}
-            {{ ns.result | list | to_json }}
-          targets: "{{ targets_json | from_json }}"
+          expanded_json: "{{ expand(grp) | map(attribute='entity_id') | list | to_json }}"
+          expanded: "{{ expanded_json | from_json(default=[]) }}"
+          targets_json: "{{ (expanded if expanded else [grp]) | to_json }}"
+          targets: "{{ targets_json | from_json(default=[]) }}"
           r: "{{ rgbw[0] | int }}"
           g: "{{ rgbw[1] | int }}"
           b: "{{ rgbw[2] | int }}"


### PR DESCRIPTION
## Summary
- convert the shelves_apply helper to encode expansion results as JSON and immediately decode to lists
- simplify target list construction so the repeat loop iterates per-entity instead of stringified payloads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d72fae0e8083259b77e7d25a246a85