### PR TITLE
Ensure Sonos doorbell chime payload always includes defaults

### DIFF
--- a/packages/ring.yaml
+++ b/packages/ring.yaml
@@ -19,6 +19,16 @@ script:
   sonos_doorbell_chime:
     alias: Sonos - Doorbell Chime (Kitchen + Patio)
     mode: single
+    variables:
+      payload: >-
+        {{
+          {
+            'players': (players | default(['media_player.kitchen', 'media_player.patio'], true)),
+            'chime_url': (chime_url | default('http://192.168.68.86:8123/local/dingdong.mp3', true)),
+            'chime_vol': (chime_vol | default(0.4, true)),
+            'chime_len': (chime_len | default('00:00:03', true))
+          } | tojson | from_json
+        }}
     fields:
       players:
         description: Sonos speakers that should play the chime
@@ -53,13 +63,7 @@ script:
           text:
     sequence:
       - service: pyscript.sonos_doorbell_chime_py
-        data: >-
-          {{ {
-            'players': players,
-            'chime_url': chime_url,
-            'chime_vol': chime_vol,
-            'chime_len': chime_len
-          } | tojson | from_json }}
+        data: "{{ payload }}"
 
   doorbell_ring_combo:
     alias: Doorbell - Chime + Shelves Flash (Pyscript)


### PR DESCRIPTION
## Summary
- build a payload variable for the Sonos doorbell chime script that injects documented defaults when parameters are omitted
- reuse the payload variable when calling the pyscript service so it always receives a fully populated structure

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d86e54020483258ba7f8accae7cb9b