### PR TITLE
Fix shelves_apply JSON serialization filters

### DIFF
--- a/packages/shelly_shelves.yaml
+++ b/packages/shelly_shelves.yaml
@@ -325,50 +325,18 @@ script:
     sequence:
       - variables:
           grp: "{{ group | default('light.shelves_all', true) }}"
-          expanded: "{{ expand(grp) | map(attribute='entity_id') | list }}"
-          targets_json: >-
-            {% set base = expanded if expanded else grp %}
-            {% if base is mapping and 'entity_id' in base %}
-              {% set base = base.entity_id %}
-            {% endif %}
-            {% if base is none %}
-              {% set items = [] %}
-            {% elif base is iterable and base is not string %}
-              {% set items = base | list %}
-            {% else %}
-              {% set items = [base] %}
-            {% endif %}
-            {% set ns = namespace(result=[]) %}
-            {% for item in items %}
-              {% if item is mapping and 'entity_id' in item %}
-                {% set inner = item.entity_id %}
-                {% if inner is iterable and inner is not string %}
-                  {% for entity in inner %}
-                    {% if entity is not none %}
-                      {% set ns.result = ns.result + [(entity | string)] %}
-                    {% endif %}
-                  {% endfor %}
-                {% elif inner is not none %}
-                  {% set ns.result = ns.result + [(inner | string)] %}
-                {% endif %}
-              {% elif item is iterable and item is not string %}
-                {% for entity in item %}
-                  {% if entity is not none %}
-                    {% set ns.result = ns.result + [(entity | string)] %}
-                  {% endif %}
-                {% endfor %}
-              {% elif item is not none %}
-                {% set ns.result = ns.result + [(item | string)] %}
-              {% endif %}
-            {% endfor %}
-            {{ ns.result | list | to_json }}
-          targets: "{{ targets_json | from_json }}"
-          r: "{{ rgbw[0] | int }}"
-          g: "{{ rgbw[1] | int }}"
-          b: "{{ rgbw[2] | int }}"
-          w: "{{ rgbw[3] | int }}"
-          bp: "{{ bright | int }}"
-          tr: "{{ trans | float(0) }}"
+          expanded_json: "{{ expand(grp) | map(attribute='entity_id') | list | tojson }}"
+          expanded: "{{ expanded_json | from_json(default=[]) }}"
+          targets_json: "{{ (expanded if expanded else [grp]) | tojson }}"
+          targets: "{{ targets_json | from_json(default=[]) }}"
+          rgbw_json: "{{ (rgbw | default([0, 0, 0, 0], true)) | tojson }}"
+          rgbw_list: "{{ rgbw_json | from_json(default=[0, 0, 0, 0]) }}"
+          r: "{{ rgbw_list[0] | int(0) }}"
+          g: "{{ rgbw_list[1] | int(0) }}"
+          b: "{{ rgbw_list[2] | int(0) }}"
+          w: "{{ rgbw_list[3] | int(0) }}"
+          bp: "{{ bright | default(100, true) | int }}"
+          tr: "{{ trans | default(0, true) | float(0) }}"
       - repeat:
           for_each: "{{ targets }}"
           sequence:


### PR DESCRIPTION
## Summary
- use Home Assistant's `tojson` filter when serializing shelf targets and color payloads so the JSON can be decoded back into real lists

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d72fae0e8083259b77e7d25a246a85