### PR TITLE
Ensure Sonos doorbell script builds default payload

### DIFF
--- a/packages/ring.yaml
+++ b/packages/ring.yaml
@@ -22,12 +22,12 @@ script:
     variables:
       payload: >-
         {{
-          {
-            'players': (players | default(['media_player.kitchen', 'media_player.patio'], true)),
-            'chime_url': (chime_url | default('http://192.168.68.86:8123/local/dingdong.mp3', true)),
-            'chime_vol': (chime_vol | default(0.4, true)),
-            'chime_len': (chime_len | default('00:00:03', true))
-          } | tojson | from_json
+          dict(
+            players=players | default(['media_player.kitchen', 'media_player.patio'], true),
+            chime_url=chime_url | default('http://192.168.68.86:8123/local/dingdong.mp3', true),
+            chime_vol=chime_vol | default(0.4, true),
+            chime_len=chime_len | default('00:00:03', true)
+          ) | tojson | from_json
         }}
     fields:
       players:


### PR DESCRIPTION
## Summary
- add a payload variable for the Sonos doorbell chime script that ensures defaults are applied to each field
- send the prebuilt payload to the pyscript service so it always receives the full data structure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d888d3e5488325b79e4ba49f99f77d