### PR TITLE
Add doorbell app to Pyscript configuration

### DIFF
--- a/pyscript/apps/apps.yaml
+++ b/pyscript/apps/apps.yaml
@@ -1,0 +1,2 @@
+doorbell:
+  module: doorbell


### PR DESCRIPTION
## Summary
- add apps.yaml to define the doorbell app module for Pyscript

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9be25a2dc8325bd2d719834f4c529