### PR TITLE
Fix doorbell import to rely on global logger

### DIFF
--- a/pyscript/apps/doorbell.py
+++ b/pyscript/apps/doorbell.py
@@ -12,7 +12,7 @@ import json
 from datetime import timedelta
 from typing import Any, Iterable, Mapping
 
-from pyscript import log, service, state, state_trigger, task, task_unique
+from pyscript import service, state, state_trigger, task, task_unique
 
 DEFAULT_CHIME_URL = "http://192.168.68.86:8123/local/dingdong.mp3"
 DEFAULT_CHIME_VOL = 0.4


### PR DESCRIPTION
## Summary
- update the doorbell pyscript to rely on Pyscript's injected global logger instead of importing it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc172ae3008325b7027c7fbe172647