### PR TITLE
Fix Pyscript apps.yaml module reference

### DIFF
--- a/pyscript/apps.yaml
+++ b/pyscript/apps.yaml
@@ -1,2 +1,2 @@
-doorbell:
-  module: "doorbell"
+apps.doorbell:
+  module: "apps.doorbell"


### PR DESCRIPTION
## Summary
- move the pyscript apps configuration to pyscript/apps.yaml
- ensure the doorbell app is registered as apps.doorbell

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc17333f0c8325a08aab6bfa1f4ffb