### PR TITLE
Remove log import from legacy doorbell aliases

### DIFF
--- a/pyscript/doorbell_aliases.py
+++ b/pyscript/doorbell_aliases.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pyscript import log, service
+from pyscript import service
 
 LEGACY_TARGETS = {
     "sonos_doorbell_chime": "sonos_doorbell_chime_py",


### PR DESCRIPTION
## Summary
- rely on Pyscript's injected log global in doorbell aliases by removing the explicit import

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc1df1a8f4832590972640f4f99a70