### PR TITLE
Remove redundant Pyscript import

### DIFF
--- a/pyscript/apps/doorbell.py
+++ b/pyscript/apps/doorbell.py
@@ -12,8 +12,6 @@ import json
 from datetime import timedelta
 from typing import Any, Iterable, Mapping
 
-from pyscript import service, state, state_trigger, task, task_unique
-
 # Note: Pyscript injects a global `log` object at runtime; no import needed.
 
 DEFAULT_CHIME_URL = "http://192.168.68.86:8123/local/dingdong.mp3"


### PR DESCRIPTION
## Summary
- remove the explicit import of Pyscript helpers from the doorbell automation module so it relies on built-in globals

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc2877a0248325b65345b311a39086