### PR TITLE
Fix pyscript doorbell app registration

### DIFF
--- a/pyscript/apps.yaml
+++ b/pyscript/apps.yaml
@@ -1,2 +1,2 @@
-apps.doorbell:
-  module: "apps.doorbell"
+doorbell:
+  module: doorbell


### PR DESCRIPTION
## Summary
- flatten the pyscript app configuration into pyscript/apps.yaml so doorbell module is referenced correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc29e139a48325aeeafff050a825ec