### PR TITLE
Clarify Pyscript runtime globals in doorbell app

### DIFF
--- a/pyscript/apps/doorbell.py
+++ b/pyscript/apps/doorbell.py
@@ -12,7 +12,8 @@ import json
 from datetime import timedelta
 from typing import Any, Iterable, Mapping
 
-# Note: Pyscript injects a global `log` object at runtime; no import needed.
+# Note: Pyscript injects globals such as `log`, `service`, `state`,
+# `state_trigger`, `task`, and `task_unique` at runtime; no import needed.
 
 DEFAULT_CHIME_URL = "http://192.168.68.86:8123/local/dingdong.mp3"
 DEFAULT_CHIME_VOL = 0.4


### PR DESCRIPTION
## Summary
- clarify that Pyscript injects the logging and task helpers at runtime in the doorbell app

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc29dfc458832588bc3857109963b8