### PR TITLE
Document Pyscript guardrails and add verification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 [![Context](https://img.shields.io/badge/ASSISTANT__CONTEXT.md-brightgreen)](https://raw.githubusercontent.com/briggswilloughby/briggs-home-automation/main/docs/ASSISTANT_CONTEXT.md)
 [![Pitfalls](https://img.shields.io/badge/KNOWN__PITFALLS.md-orange)](https://raw.githubusercontent.com/briggswilloughby/briggs-home-automation/main/docs/KNOWN-PITFALLS.md)
 [![Changelog](https://img.shields.io/badge/CHANGELOG.md-yellow)](https://raw.githubusercontent.com/briggswilloughby/briggs-home-automation/main/CHANGELOG.md)
+[![Pyscript Anchor](https://img.shields.io/badge/AGENT__ANCHOR.md-purple)](https://raw.githubusercontent.com/briggswilloughby/briggs-home-automation/main/docs/AGENT_ANCHOR.md)
+[![Pyscript Playbook](https://img.shields.io/badge/HA__PYSCRIPT__PLAYBOOK.md-lightgrey)](https://raw.githubusercontent.com/briggswilloughby/briggs-home-automation/main/docs/HA_PYSCRIPT_PLAYBOOK.md)
+[![Troubleshooting](https://img.shields.io/badge/TROUBLESHOOTING.md-red)](https://raw.githubusercontent.com/briggswilloughby/briggs-home-automation/main/docs/TROUBLESHOOTING.md)
 
 This repository contains my Home Assistant configuration and related automation scripts. It is the single source of truth for my smart home setup, including Sonos, Shelly RGBW2, Ring, Lutron, Google Assistant, and custom YAML automations.
 
@@ -50,7 +53,14 @@ This repository contains my Home Assistant configuration and related automation 
 - [KICKOFF.md](https://raw.githubusercontent.com/briggswilloughby/briggs-home-automation/main/KICKOFF.md)
 - [ASSISTANT_CONTEXT.md](https://raw.githubusercontent.com/briggswilloughby/briggs-home-automation/main/docs/ASSISTANT_CONTEXT.md)
 - [KNOWN-PITFALLS.md](https://raw.githubusercontent.com/briggswilloughby/briggs-home-automation/main/docs/KNOWN-PITFALLS.md)
+- [Pyscript Apps Anchor](https://raw.githubusercontent.com/briggswilloughby/briggs-home-automation/main/docs/AGENT_ANCHOR.md)
+- [Pyscript Ops Playbook](https://raw.githubusercontent.com/briggswilloughby/briggs-home-automation/main/docs/HA_PYSCRIPT_PLAYBOOK.md)
+- [Pyscript Troubleshooting](https://raw.githubusercontent.com/briggswilloughby/briggs-home-automation/main/docs/TROUBLESHOOTING.md)
 
 ### Home Assistant Packages
 
 - [sonos.yaml](https://raw.githubusercontent.com/briggswilloughby/briggs-home-automation/main/home-assistant/packages/sonos.yaml)
+
+### Tooling
+
+- [`scripts/verify_pyscript.sh`](scripts/verify_pyscript.sh): run inside your Docker host to validate the apps-mode mapping, configuration include, import guardrail, and recent log output before deploying.

--- a/docs/AGENT_ANCHOR.md
+++ b/docs/AGENT_ANCHOR.md
@@ -1,0 +1,20 @@
+# Pyscript Apps-Mode Anchor
+
+This anchor supplements `docs/ASSISTANT_CONTEXT.md` with guardrails that keep the Home Assistant Pyscript integration operating in apps mode. Treat these as hard requirements whenever you touch anything under `pyscript/`.
+
+## Guardrails
+
+1. **Apps-only layout** – Modules live in `pyscript/apps/` and are registered in `pyscript/apps.yaml`. Do not place runnable code in the package root.
+2. **One service per capability** – Expose entry points with `@service` decorators; helpers stay private (`_helper()`). Keep names snake_case to align with ADR-0002.
+3. **No direct imports** – Pyscript injects `@service`, `task`, `service`, `log`, etc. Avoid `import`/`from` statements unless absolutely unavoidable (and document the exception in-line).
+4. **Async first** – Prefer `async def` services when calling Home Assistant services or waiting on tasks. Use `await task.sleep()` for timing instead of `time.sleep()`.
+5. **Idempotent side effects** – Guard long-running work with `await task.unique()` when it should not overlap, and validate inputs before calling Home Assistant services.
+6. **Minimal configuration coupling** – Keep entity IDs and helpers defined in YAML packages. Accept them as service kwargs instead of hard-coding when practical.
+
+## Review checklist
+
+Before committing Pyscript changes:
+
+- Confirm every module referenced in `apps.yaml` exists and loads without syntax errors.
+- Re-run `scripts/verify_pyscript.sh` (see README) from your workstation and resolve any failures.
+- Validate new services show up under **Developer Tools → Actions** and document usage in the CHANGELOG when shipped.

--- a/docs/HA_PYSCRIPT_PLAYBOOK.md
+++ b/docs/HA_PYSCRIPT_PLAYBOOK.md
@@ -1,0 +1,42 @@
+# Home Assistant Pyscript Daily Ops Playbook
+
+Use this playbook when you update, deploy, or validate the Pyscript apps that live under `/config/pyscript` on the Home Assistant host.
+
+## 1. Prep the repo
+
+1. Pull latest `main` and sync secrets as needed.
+2. Edit Python apps in `pyscript/apps/` and update `pyscript/apps.yaml` if new modules are introduced.
+3. Update YAML packages or docs that reference the new services.
+
+## 2. Run local checks
+
+1. `yamllint` + `hass --script check_config` (handled by CI, but run locally when touching YAML).
+2. Execute `scripts/verify_pyscript.sh` (see below) to confirm the container mapping, configuration include, import guardrail, and that logs are healthy.
+3. Commit, push, and open a PR summarizing the change and any new services.
+
+## 3. Deploy on the Home Assistant host
+
+1. `git pull` the repo on the host (usually `/config`).
+2. Restart or reload Pyscript apps:
+   - Home Assistant UI → **Developer Tools → YAML → Reload Pyscript Apps** (or restart the add-on if reload fails).
+3. Watch the Home Assistant **Notifications** panel for load errors.
+
+## 4. Post-deploy validation
+
+1. Confirm new services appear under **Developer Tools → Actions**.
+2. Manually trigger critical services (e.g., doorbell flash) to ensure runtime behavior matches expectations.
+3. Tail the Pyscript log (see troubleshooting) for warnings or tracebacks.
+
+## Reference: verification script
+
+`scripts/verify_pyscript.sh` expects Docker access and defaults to container `homeassistant` with config mounted at `/config`. Override with environment variables if your setup differs:
+
+```bash
+HA_CONTAINER=my-ha ./scripts/verify_pyscript.sh
+```
+
+Environment variables:
+
+- `HA_CONTAINER`: name or ID of the running Home Assistant container (default `homeassistant`).
+- `CONFIG_PATH`: path to the mounted config directory inside the container (default `/config`).
+- `APPS_DIR`: path to the Pyscript apps directory inside the container (default `$CONFIG_PATH/pyscript/apps`).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,30 @@
+# Pyscript Troubleshooting Guide
+
+Use this guide to diagnose and recover from common Pyscript issues in the Briggs Home Assistant deployment.
+
+## Logs
+
+- Tail the runtime log inside the container: `docker exec -it homeassistant tail -f /config/pyscript/logs/pyscript.log`
+- When debugging service calls, temporarily raise log level in `configuration.yaml` under `logger:` for `custom_components.pyscript`.
+- Capture relevant excerpts and attach them to issues/PRs.
+
+## Common problems & fixes
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Services missing from Developer Tools | Module not registered in `pyscript/apps.yaml` or syntax error preventing load | Run `scripts/verify_pyscript.sh` and reload Pyscript Apps. Check Home Assistant notifications for tracebacks. |
+| `NameError` / missing helpers | Direct `import` usage or reliance on unavailable globals | Remove imports, rely on injected helpers (`log`, `task`, `service`). Confirm guardrails in `docs/AGENT_ANCHOR.md`. |
+| Pyscript reload fails silently | Cached task still running | Use `await task.unique("<name>", kill_me=True)` in long-running services; restart Pyscript from UI if needed. |
+| Lighting automations stuck on | Loop terminated early, leaving lights on | Ensure loops balance `turn_on`/`turn_off` even on exceptions. Add `try/finally` cleanup if necessary. |
+| Logs full of `Event loop is closed` | Home Assistant restart interrupted running tasks | Restart Home Assistant container. Inspect logs for root cause before bringing automations back online. |
+
+## Escalation checklist
+
+1. Run `scripts/verify_pyscript.sh` and confirm all checks pass.
+2. Reload Pyscript Apps from the UI.
+3. If errors persist, restart the Home Assistant container (`docker restart homeassistant`).
+4. Still failing? Open an issue with:
+   - Steps to reproduce
+   - Relevant log excerpts
+   - Mention of any ADR conflicts or guardrail violations
+5. Document the fix in `CHANGELOG.md` once resolved.

--- a/scripts/verify_pyscript.sh
+++ b/scripts/verify_pyscript.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HA_CONTAINER=${HA_CONTAINER:-homeassistant}
+CONFIG_PATH=${CONFIG_PATH:-/config}
+APPS_DIR=${APPS_DIR:-${CONFIG_PATH}/pyscript/apps}
+APPS_MAP=${APPS_MAP:-${CONFIG_PATH}/pyscript/apps.yaml}
+LOG_FILE=${LOG_FILE:-${CONFIG_PATH}/pyscript/logs/pyscript.log}
+
+step() {
+    printf '\n▶ %s\n' "$1"
+}
+
+step "Confirming Pyscript apps mapping"
+docker exec "$HA_CONTAINER" bash -c "test -d '$APPS_DIR' && test -f '$APPS_MAP'"
+
+docker exec "$HA_CONTAINER" bash -c "python - <<'PY'
+import pathlib, sys
+apps_dir = pathlib.Path(r'${APPS_DIR}')
+apps_map = pathlib.Path(r'${APPS_MAP}')
+missing = []
+if not apps_map.exists():
+    sys.exit('apps.yaml not found')
+for raw in apps_map.read_text().splitlines():
+    line = raw.strip()
+    if not line or line.startswith('#'):
+        continue
+    if line.endswith(':') and not line.startswith(('module', '-')):
+        continue
+    if line.startswith('module:'):
+        module = line.split(':', 1)[1].strip()
+        module_path = apps_dir / f"{module}.py"
+        if not module_path.exists():
+            missing.append(module_path)
+if missing:
+    print('Missing module files:')
+    for path in missing:
+        print(f'  - {path}')
+    sys.exit(1)
+PY"
+
+step "Checking configuration.yaml includes pyscript apps map"
+DOCKER_CMD="grep -E '^\\s*apps:\\s*!include\\s+pyscript/apps.yaml' '$CONFIG_PATH/configuration.yaml'"
+docker exec "$HA_CONTAINER" bash -c "$DOCKER_CMD" >/dev/null
+
+step "Ensuring Pyscript apps avoid direct imports"
+docker exec "$HA_CONTAINER" bash -c "python - <<'PY'"
+import pathlib, re, sys
+apps_dir = pathlib.Path(r'${APPS_DIR}')
+pattern = re.compile(r'^\s*(from|import)\s+')
+violations = []
+for path in sorted(apps_dir.glob('*.py')):
+    if path.name == '__init__.py':
+        continue
+    try:
+        lines = path.read_text().splitlines()
+    except Exception as exc:  # noqa: BLE001
+        violations.append(f"{path}: unable to read ({exc})")
+        continue
+    for idx, line in enumerate(lines, 1):
+        if pattern.match(line):
+            violations.append(f"{path}:{idx}:{line.strip()}")
+if violations:
+    print('Direct imports detected:')
+    for item in violations:
+        print(f'  - {item}')
+    sys.exit(1)
+PY"
+
+step "Showing recent Pyscript log lines"
+docker exec "$HA_CONTAINER" bash -c "if [ -f '$LOG_FILE' ]; then tail -n 40 '$LOG_FILE'; else echo 'Pyscript log not found at $LOG_FILE' >&2; exit 1; fi"
+
+step "All checks completed"


### PR DESCRIPTION
## Summary
- add dedicated docs covering Pyscript apps-mode guardrails, daily operations, and troubleshooting guidance
- create a Docker-focused verification helper script that validates mapping, configuration includes, import rules, and log health
- surface the new docs and script from the README for quick discovery

## Testing
- not run (documentation and scripting only)


------
https://chatgpt.com/codex/tasks/task_e_68dc8b0a30f88325999c2cc84aaa9935