### PR TITLE
Update doorbell flash targets

### DIFF
--- a/packages/modes.yaml
+++ b/packages/modes.yaml
@@ -62,6 +62,12 @@ script:
     mode: restart
     sequence:
       - service: pyscript.shelves_doorbell_flash_py
+        data:
+          targets:
+            - light.shelf_1
+            - light.shelf_2
+            - light.shelf_3
+            - light.shelf_4
       # Optionally:
       # - service: script.sonos_announce
       #   data:


### PR DESCRIPTION
## Summary
- add target light entities to the doorbell flash combo so the pyscript knows which shelves to flash

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc92d100308325a39834207c8a9ae5