### PR TITLE
Align doorbell flash targets payload

### DIFF
--- a/packages/modes.yaml
+++ b/packages/modes.yaml
@@ -63,11 +63,7 @@ script:
     sequence:
       - service: pyscript.shelves_doorbell_flash_py
         data:
-          targets:
-            - light.shelf_1
-            - light.shelf_2
-            - light.shelf_3
-            - light.shelf_4
+          targets: ['light.shelf_1', 'light.shelf_2', 'light.shelf_3', 'light.shelf_4']
       # Optionally:
       # - service: script.sonos_announce
       #   data:


### PR DESCRIPTION
## Summary
- update the doorbell flash combo script to pass shelves targets as an explicit list for pyscript

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd9199ce3c8325bf70b32f5b193416