### PR TITLE
Normalize Shelly shelf mode detection list conversion

### DIFF
--- a/packages/shelly_shelves.yaml
+++ b/packages/shelly_shelves.yaml
@@ -339,7 +339,7 @@ script:
           for_each: "{{ targets_list }}"
           sequence:
             - variables:
-                supported_modes: "{{ state_attr(repeat.item, 'supported_color_modes') | default([], true) }}"
+                supported_modes: "{{ (state_attr(repeat.item, 'supported_color_modes') | default([], true)) | list }}"
             - choose:
                 - conditions: "{{ 'rgbww' in supported_modes }}"
                   sequence:


### PR DESCRIPTION
## Summary
- ensure `script.shelves_apply` casts each light's `supported_color_modes` to a list before selecting the correct color payload

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e19c0368a88325bf6a25b5c37d28ec