### PR TITLE
Handle doorbell state lookup without deprecated attribute arg

### DIFF
--- a/pyscript/apps/doorbell.py
+++ b/pyscript/apps/doorbell.py
@@ -43,17 +43,19 @@ def _get_entity_details(entity_id):
 
     try:
         state_value = state.get(entity_id)
-    except (NameError, KeyError):
+    except (NameError, KeyError, AttributeError):
         state_value = None
     except Exception as err:  # pragma: no cover - defensive logging
         log.warning("shelves_flash: error retrieving state for %s: %s", entity_id, err)
         state_value = None
 
     try:
-        attributes = state.getattr(entity_id)
-        if not isinstance(attributes, dict):
+        entity_attributes = state.getattr(entity_id)
+        if isinstance(entity_attributes, dict):
+            attributes = entity_attributes
+        else:
             attributes = {}
-    except (NameError, KeyError):
+    except (NameError, KeyError, AttributeError):
         attributes = {}
     except Exception as err:  # pragma: no cover - defensive logging
         log.warning("shelves_flash: error retrieving attributes for %s: %s", entity_id, err)


### PR DESCRIPTION
## Summary
- update the doorbell app to use separate state.get and state.getattr calls
- guard entity lookups so missing entities do not interrupt flashing logic

## Testing
- not run (home assistant environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e19c83a160832596d52b258ec0a6a2