### PR TITLE
Handle Shelly shelves color mode capabilities

### DIFF
--- a/packages/shelly_shelves.yaml
+++ b/packages/shelly_shelves.yaml
@@ -339,7 +339,7 @@ script:
           for_each: "{{ targets_list }}"
           sequence:
             - variables:
-                supported_modes: "{{ (state_attr(repeat.item, 'supported_color_modes') | default([], true)) | list }}"
+                supported_modes: "{{ state_attr(repeat.item, 'supported_color_modes') | default([], true) }}"
             - choose:
                 - conditions: "{{ 'rgbww' in supported_modes }}"
                   sequence:


### PR DESCRIPTION
## Summary
- derive each shelf target's supported color modes before applying state changes
- send rgbww, rgbw, or rgb color payloads that match the light's capabilities while keeping brightness and transition settings

## Testing
- not run (environment only provides static analysis)

------
https://chatgpt.com/codex/tasks/task_e_68e1a0cbcaf08325968110b3b7d2b261