### PR TITLE
Handle Shelly shelves color mode variants

### DIFF
--- a/packages/shelly_shelves.yaml
+++ b/packages/shelly_shelves.yaml
@@ -340,45 +340,19 @@ script:
           sequence:
             - variables:
                 supported_modes: "{{ state_attr(repeat.item, 'supported_color_modes') | default([], true) }}"
-            - choose:
-                - conditions: "{{ 'rgbww' in supported_modes }}"
-                  sequence:
-                    - service: light.turn_on
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                      data:
-                        rgbww_color:
-                          - "{{ r | int }}"
-                          - "{{ g | int }}"
-                          - "{{ b | int }}"
-                          - "{{ cw | int }}"
-                          - "{{ ww | int }}"
-                        brightness_pct: "{{ bp }}"
-                        transition: "{{ tr }}"
-                - conditions: "{{ 'rgbw' in supported_modes }}"
-                  sequence:
-                    - service: light.turn_on
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                      data:
-                        rgbw_color:
-                          - "{{ r | int }}"
-                          - "{{ g | int }}"
-                          - "{{ b | int }}"
-                          - "{{ cw | int }}"
-                        brightness_pct: "{{ bp }}"
-                        transition: "{{ tr }}"
-              default:
-                - service: light.turn_on
-                  target:
-                    entity_id: "{{ repeat.item }}"
-                  data:
-                    rgb_color:
-                      - "{{ r | int }}"
-                      - "{{ g | int }}"
-                      - "{{ b | int }}"
-                    brightness_pct: "{{ bp }}"
-                    transition: "{{ tr }}"
+                color_payload: >
+                  {% set base = {'brightness_pct': bp, 'transition': tr} %}
+                  {% if 'rgbww' in supported_modes %}
+                    {{ base | combine({'rgbww_color': [r|int, g|int, b|int, cw|int, ww|int]}) | tojson }}
+                  {% elif 'rgbw' in supported_modes %}
+                    {{ base | combine({'rgbw_color': [r|int, g|int, b|int, cw|int]}) | tojson }}
+                  {% else %}
+                    {{ base | combine({'rgb_color': [r|int, g|int, b|int]}) | tojson }}
+                  {% endif %}
+            - service: light.turn_on
+              target:
+                entity_id: "{{ repeat.item }}"
+              data: "{{ color_payload | from_json }}"
 
 #########################
 # 4) OPTIONAL AUTOMATIONS


### PR DESCRIPTION
## Summary
- collect each shelf light's supported color modes before turning it on
- build the light.turn_on payload dynamically so rgbww, rgbw, and rgb-only devices receive appropriate keys while preserving brightness and transition

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1a5c438548325bc5195fa0c46ed05