### PR TITLE
Fix doorbell pyscript entity attribute lookup

### DIFF
--- a/pyscript/apps/doorbell.py
+++ b/pyscript/apps/doorbell.py
@@ -63,14 +63,15 @@ def _get_entity_details(entity_id):
 
     try:
         entity_attributes = state.getattr(entity_id)
-        if isinstance(entity_attributes, Mapping):
-            attributes = dict(entity_attributes)
-        else:
-            attributes = {}
     except (NameError, KeyError, AttributeError):
-        attributes = {}
+        entity_attributes = None
     except Exception as err:  # pragma: no cover - defensive logging
         log.warning("shelves_flash: error retrieving attributes for %s: %s", entity_id, err)
+        entity_attributes = None
+
+    if isinstance(entity_attributes, Mapping):
+        attributes = dict(entity_attributes)
+    else:
         attributes = {}
 
     if not attributes and legacy_attributes:


### PR DESCRIPTION
## Summary
- call `state.get(entity_id)` for the entity state payload in `_get_entity_details`
- retrieve attributes via `state.getattr` while keeping compatibility with legacy mappings

## Testing
- not run (pyscript environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1a8bd4b888325a7b6a64a1efb51e7