### PR TITLE
Handle Shelly shelf color mode support

### DIFF
--- a/packages/shelly_shelves.yaml
+++ b/packages/shelly_shelves.yaml
@@ -340,19 +340,45 @@ script:
           sequence:
             - variables:
                 supported_modes: "{{ state_attr(repeat.item, 'supported_color_modes') | default([], true) }}"
-                color_payload: >
-                  {% set base = {'brightness_pct': bp, 'transition': tr} %}
-                  {% if 'rgbww' in supported_modes %}
-                    {{ base | combine({'rgbww_color': [r|int, g|int, b|int, cw|int, ww|int]}) | tojson }}
-                  {% elif 'rgbw' in supported_modes %}
-                    {{ base | combine({'rgbw_color': [r|int, g|int, b|int, cw|int]}) | tojson }}
-                  {% else %}
-                    {{ base | combine({'rgb_color': [r|int, g|int, b|int]}) | tojson }}
-                  {% endif %}
-            - service: light.turn_on
-              target:
-                entity_id: "{{ repeat.item }}"
-              data: "{{ color_payload | from_json }}"
+            - choose:
+                - conditions: "{{ 'rgbww' in supported_modes }}"
+                  sequence:
+                    - service: light.turn_on
+                      target:
+                        entity_id: "{{ repeat.item }}"
+                      data:
+                        brightness_pct: {{ bp | int }}
+                        transition: {{ tr | float }}
+                        rgbww_color:
+                          - {{ r | int }}
+                          - {{ g | int }}
+                          - {{ b | int }}
+                          - {{ cw | int }}
+                          - {{ ww | int }}
+                - conditions: "{{ 'rgbw' in supported_modes }}"
+                  sequence:
+                    - service: light.turn_on
+                      target:
+                        entity_id: "{{ repeat.item }}"
+                      data:
+                        brightness_pct: {{ bp | int }}
+                        transition: {{ tr | float }}
+                        rgbw_color:
+                          - {{ r | int }}
+                          - {{ g | int }}
+                          - {{ b | int }}
+                          - {{ cw | int }}
+              default:
+                - service: light.turn_on
+                  target:
+                    entity_id: "{{ repeat.item }}"
+                  data:
+                    brightness_pct: {{ bp | int }}
+                    transition: {{ tr | float }}
+                    rgb_color:
+                      - {{ r | int }}
+                      - {{ g | int }}
+                      - {{ b | int }}
 
 #########################
 # 4) OPTIONAL AUTOMATIONS


### PR DESCRIPTION
## Summary
- detect each shelf light's supported color modes before issuing light.turn_on
- branch between rgbww, rgbw, and rgb payloads while keeping brightness and transition data

## Testing
- not run (Home Assistant scripts and voice commands unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1a8bcab348325aac4987f114a6b33