### PR TITLE
Handle Shelly shelves color modes dynamically

### DIFF
--- a/packages/shelly_shelves.yaml
+++ b/packages/shelly_shelves.yaml
@@ -339,46 +339,23 @@ script:
           for_each: "{{ targets_list }}"
           sequence:
             - variables:
-                supported_modes: "{{ state_attr(repeat.item, 'supported_color_modes') | default([], true) }}"
-            - choose:
-                - conditions: "{{ 'rgbww' in supported_modes }}"
-                  sequence:
-                    - service: light.turn_on
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                      data:
-                        brightness_pct: {{ bp | int }}
-                        transition: {{ tr | float }}
-                        rgbww_color:
-                          - {{ r | int }}
-                          - {{ g | int }}
-                          - {{ b | int }}
-                          - {{ cw | int }}
-                          - {{ ww | int }}
-                - conditions: "{{ 'rgbw' in supported_modes }}"
-                  sequence:
-                    - service: light.turn_on
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                      data:
-                        brightness_pct: {{ bp | int }}
-                        transition: {{ tr | float }}
-                        rgbw_color:
-                          - {{ r | int }}
-                          - {{ g | int }}
-                          - {{ b | int }}
-                          - {{ cw | int }}
-              default:
-                - service: light.turn_on
-                  target:
-                    entity_id: "{{ repeat.item }}"
-                  data:
-                    brightness_pct: {{ bp | int }}
-                    transition: {{ tr | float }}
-                    rgb_color:
-                      - {{ r | int }}
-                      - {{ g | int }}
-                      - {{ b | int }}
+                supported_modes: >-
+                  {{ state_attr(repeat.item, 'supported_color_modes') | default([], true) | list }}
+                color_payload: >-
+                  {% if 'rgbww' in supported_modes %}
+                    {{ {'rgbww_color': [r | int, g | int, b | int, cw | int, ww | int]} | tojson }}
+                  {% elif 'rgbw' in supported_modes %}
+                    {{ {'rgbw_color': [r | int, g | int, b | int, cw | int]} | tojson }}
+                  {% else %}
+                    {{ {'rgb_color': [r | int, g | int, b | int]} | tojson }}
+                  {% endif %}
+            - service: light.turn_on
+              target:
+                entity_id: "{{ repeat.item }}"
+              data:
+                brightness_pct: {{ bp | int }}
+                transition: {{ tr | float }}
+                <<: "{{ color_payload | from_json }}"
 
 #########################
 # 4) OPTIONAL AUTOMATIONS


### PR DESCRIPTION
## Summary
- detect each target light's supported color modes in the Shelly shelves helper
- send rgbww, rgbw, or rgb payloads accordingly while retaining brightness and transition settings

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1aa97e4148325a17e126c4b7a35a9