### PR TITLE
Handle supported color modes in shelves_apply helper

### DIFF
--- a/packages/shelly_shelves.yaml
+++ b/packages/shelly_shelves.yaml
@@ -341,21 +341,52 @@ script:
             - variables:
                 supported_modes: >-
                   {{ state_attr(repeat.item, 'supported_color_modes') | default([], true) | list }}
-                color_payload: >-
-                  {% if 'rgbww' in supported_modes %}
-                    {{ {'rgbww_color': [r | int, g | int, b | int, cw | int, ww | int]} | tojson }}
-                  {% elif 'rgbw' in supported_modes %}
-                    {{ {'rgbw_color': [r | int, g | int, b | int, cw | int]} | tojson }}
-                  {% else %}
-                    {{ {'rgb_color': [r | int, g | int, b | int]} | tojson }}
-                  {% endif %}
-            - service: light.turn_on
-              target:
-                entity_id: "{{ repeat.item }}"
-              data:
-                brightness_pct: {{ bp | int }}
-                transition: {{ tr | float }}
-                <<: "{{ color_payload | from_json }}"
+            - if:
+                - condition: template
+                  value_template: "{{ 'rgbww' in supported_modes }}"
+              then:
+                - service: light.turn_on
+                  target:
+                    entity_id: "{{ repeat.item }}"
+                  data:
+                    brightness_pct: {{ bp | int }}
+                    transition: {{ tr | float }}
+                    rgbww_color: [
+                      {{ r | int }},
+                      {{ g | int }},
+                      {{ b | int }},
+                      {{ cw | int }},
+                      {{ ww | int }}
+                    ]
+              else:
+                - if:
+                    - condition: template
+                      value_template: "{{ 'rgbw' in supported_modes }}"
+                  then:
+                    - service: light.turn_on
+                      target:
+                        entity_id: "{{ repeat.item }}"
+                      data:
+                        brightness_pct: {{ bp | int }}
+                        transition: {{ tr | float }}
+                        rgbw_color: [
+                          {{ r | int }},
+                          {{ g | int }},
+                          {{ b | int }},
+                          {{ cw | int }}
+                        ]
+                  else:
+                    - service: light.turn_on
+                      target:
+                        entity_id: "{{ repeat.item }}"
+                      data:
+                        brightness_pct: {{ bp | int }}
+                        transition: {{ tr | float }}
+                        rgb_color: [
+                          {{ r | int }},
+                          {{ g | int }},
+                          {{ b | int }}
+                        ]
 
 #########################
 # 4) OPTIONAL AUTOMATIONS


### PR DESCRIPTION
## Summary
- determine each shelf light's supported color modes before turning on the light
- send rgbww, rgbw, or rgb payloads conditionally while keeping brightness and transition controls intact

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2c3930c208325835571d613dec33c