### PR TITLE
Handle multi-mode shelves helper color commands

### DIFF
--- a/packages/shelly_shelves.yaml
+++ b/packages/shelly_shelves.yaml
@@ -339,30 +339,25 @@ script:
           for_each: "{{ targets_list }}"
           sequence:
             - variables:
-                supported_modes: >-
-                  {{ state_attr(repeat.item, 'supported_color_modes') | default([], true) | list }}
-            - if:
-                - condition: template
-                  value_template: "{{ 'rgbww' in supported_modes }}"
-              then:
-                - service: light.turn_on
-                  target:
-                    entity_id: "{{ repeat.item }}"
-                  data:
-                    brightness_pct: {{ bp | int }}
-                    transition: {{ tr | float }}
-                    rgbww_color: [
-                      {{ r | int }},
-                      {{ g | int }},
-                      {{ b | int }},
-                      {{ cw | int }},
-                      {{ ww | int }}
-                    ]
-              else:
-                - if:
-                    - condition: template
-                      value_template: "{{ 'rgbw' in supported_modes }}"
-                  then:
+                modes: "{{ state_attr(repeat.item, 'supported_color_modes') | default([], true) }}"
+            - choose:
+                - conditions: "{{ 'rgbww' in modes }}"
+                  sequence:
+                    - service: light.turn_on
+                      target:
+                        entity_id: "{{ repeat.item }}"
+                      data:
+                        brightness_pct: {{ bp | int }}
+                        transition: {{ tr | float }}
+                        rgbww_color: [
+                          {{ r | int }},
+                          {{ g | int }},
+                          {{ b | int }},
+                          {{ cw | int }},
+                          {{ ww | int }}
+                        ]
+                - conditions: "{{ 'rgbw' in modes }}"
+                  sequence:
                     - service: light.turn_on
                       target:
                         entity_id: "{{ repeat.item }}"
@@ -375,18 +370,18 @@ script:
                           {{ b | int }},
                           {{ cw | int }}
                         ]
-                  else:
-                    - service: light.turn_on
-                      target:
-                        entity_id: "{{ repeat.item }}"
-                      data:
-                        brightness_pct: {{ bp | int }}
-                        transition: {{ tr | float }}
-                        rgb_color: [
-                          {{ r | int }},
-                          {{ g | int }},
-                          {{ b | int }}
-                        ]
+              default:
+                - service: light.turn_on
+                  target:
+                    entity_id: "{{ repeat.item }}"
+                  data:
+                    brightness_pct: {{ bp | int }}
+                    transition: {{ tr | float }}
+                    rgb_color: [
+                      {{ r | int }},
+                      {{ g | int }},
+                      {{ b | int }}
+                    ]
 
 #########################
 # 4) OPTIONAL AUTOMATIONS


### PR DESCRIPTION
## Summary
- set per-target supported color modes inside the shelves_apply helper
- use a choose block to target rgbww, rgbw, or rgb payloads while keeping brightness and transition data

## Testing
- ha scripts reload *(fails: command not found in container)*
- ha core check *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d20397c88325bd9b0c10e9103bab